### PR TITLE
Support query's 'context' parameter

### DIFF
--- a/.changeset/wear-a-mask.md
+++ b/.changeset/wear-a-mask.md
@@ -1,0 +1,5 @@
+---
+"@ts-gql/apollo": patch
+---
+
+Support `query`'s `context` parameter, and tightens up `mutate`'s existing `context` parameter to be [more in line with Apollo's](https://github.com/apollographql/apollo-client/blob/main/src/core/types.ts#L16).

--- a/packages/apollo/index.d.ts
+++ b/packages/apollo/index.d.ts
@@ -165,7 +165,7 @@ export type MutationOptions<
   TTypedDocumentNode extends TypedDocumentNode<BaseTypedMutation>
 > = {
   mutation: TTypedDocumentNode;
-  context?: any;
+  context?: Record<string, any>;
   fetchPolicy?: FetchPolicy;
   optimisticResponse?:
     | OperationData<TTypedDocumentNode>
@@ -193,6 +193,7 @@ type QueryFnOptions<
   query: TTypedDocumentNode;
   errorPolicy?: ErrorPolicy;
   fetchPolicy?: FetchPolicy;
+  context?: Record<string, any>;
 } & HasRequiredVariables<
   TTypedDocumentNode,
   { variables: OperationVariables<TTypedDocumentNode> },


### PR DESCRIPTION
Fixes https://github.com/Thinkmill/ts-gql/issues/85

Also tightens up `mutate`'s existing 'context' parameter to be more in line with Apollo's: https://github.com/apollographql/apollo-client/blob/main/src/core/types.ts#L16